### PR TITLE
Include as_user argument to post messages as the authed user

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ SlackBot Configuration
 - events: list of events to track, as defined in `luigi_slack.events` (default=[FAILURE])
 - max_events: max number of events of the same type displayed, before a "please check logs" message is given (default=5)
 - username: the screen name of your bot (default='Luigi-slack Bot')
+- as_user: true to post the message as the authenticated user (default=False). When true the argument username is ignored.
 - task_representation: the function used to give a string representation of the task (default=str)
 - print_env: list of environment variables to include in the notification (default=[]). Useful when running multiple pipelines/environments and sending the notification in a single Slack channel.
 

--- a/luigi_slack/api.py
+++ b/luigi_slack/api.py
@@ -32,6 +32,7 @@ class SlackBot(object):
                  events=[FAILURE],
                  max_events=5,
                  username='Luigi-slack Bot',
+                 as_user=False,
                  task_representation=str,
                  print_env=[]):
         if not isinstance(events, list):
@@ -40,7 +41,7 @@ class SlackBot(object):
             log.info('SlackBot(channels=[]): notifications are not sent')
         self.events = events
         self._events_to_handle = self.events + [START]
-        self.client = SlackAPI(token, username)
+        self.client = SlackAPI(token, username, as_user)
         self.channels = channels
         self.max_events = max_events
         self.event_queue = defaultdict(list)

--- a/luigi_slack/slack_api.py
+++ b/luigi_slack/slack_api.py
@@ -16,10 +16,11 @@ class ChannelListNotLoadedError(Exception):
 
 class SlackAPI(object):
 
-    def __init__(self, token, username='Luigi-slack Bot'):
+    def __init__(self, token, username='Luigi-slack Bot', as_user=False):
         self.client = SlackClient(token)
         self._all_channels = self._get_channels()
         self.username = username
+        self.as_user = as_user
 
     def _get_channels(self):
         response = self.client.api_call('channels.list')
@@ -58,7 +59,8 @@ class SlackAPI(object):
                                             text=message.title,
                                             attachments=attachments,
                                             channel=channel,
-                                            username=self.username)
+                                            username=self.username,
+                                            as_user=self.as_user)
             log.debug(response)
             if not response['ok']:
                 log.debug("Error while posting message to {}: {}".format(channel, response['error']))


### PR DESCRIPTION
I thought it would be nice to be able to post the luigi notifications as a user/bot.
Before, all notifications arrived in slackbot with the customized username.  This PR allows setting `as_user=True` that makes the messages arrive in a user/bot chat, determined authomatically from the slack token.

(only tested with single users `@username` and not with channels)