### PR TITLE
Adds SUCCESS to SlackBot._events_to_handle. Was causing unreachable code

### DIFF
--- a/luigi_slack/api.py
+++ b/luigi_slack/api.py
@@ -40,7 +40,7 @@ class SlackBot(object):
         if not channels:
             log.info('SlackBot(channels=[]): notifications are not sent')
         self.events = events
-        self._events_to_handle = self.events + [START]
+        self._events_to_handle = self.events + [SUCCESS, START]
         self.client = SlackAPI(token, username, as_user)
         self.channels = channels
         self.max_events = max_events


### PR DESCRIPTION
The part **`else: return None`** statement in the snippet
```
    def _format_message(self):
        job = os.path.basename(inspect.stack()[-1][1])
        title = "*Status report for {}*".format(job)
        if self._only_success():
            if SUCCESS in self.events:
                messages = {event_label(SUCCESS): ["Job ran successfully!"]}
                success = True
            else:
                return None
```

was unreachable due to the method `_only_success(self)`. 
 In `_only_success(self)`, there is a comparison of the number of successful events with the number of started events. 
But if `SUCCESS` is not part of `self.events` the successful events are never handled, and so the method `_only_success()` will always return false if the user has not put `SUCCESS` in `self.events`. If they had put it in, then the first conditional in the `_format_message()` snippet will always evaluate to True, thus ensuring that the `else` condition will never be reached.